### PR TITLE
Add SNR calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,15 @@ This project fetches and displays stock prices and their percentage changes usin
 ## Dependencies
 
 - [http-server](https://www.npmjs.com/package/http-server) (if using a simple HTTP server)
+
+## Signal-to-Noise Ratio
+
+The `snr_calculator.py` script computes the signal-to-noise ratio (SNR) for a stock's closing prices. Provide a CSV file that includes a `Close` column of prices.
+
+Run the script with:
+
+```bash
+python snr_calculator.py path/to/your_data.csv
+```
+
+It outputs the SNR of the daily returns calculated from the closing prices.

--- a/snr_calculator.py
+++ b/snr_calculator.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import numpy as np
+import argparse
+
+
+def compute_snr(close_prices: pd.Series) -> float:
+    """Calculate signal-to-noise ratio from a series of closing prices."""
+    returns = close_prices.pct_change().dropna()
+    signal = returns.mean()
+    noise = returns.std()
+    if noise == 0:
+        return float('inf')
+    return float(signal / noise)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Calculate signal-to-noise ratio of stock prices from a CSV file.")
+    parser.add_argument("csv_file", help="CSV file with at least a 'Close' column")
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.csv_file)
+    if 'Close' not in df.columns:
+        raise ValueError("CSV file must contain a 'Close' column")
+
+    snr = compute_snr(df['Close'])
+    print(f"Signal-to-noise ratio: {snr:.4f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `snr_calculator.py` for computing the signal-to-noise ratio of stock prices
- document usage in `README.md`

## Testing
- `python snr_calculator.py --help` *(fails: ModuleNotFoundError: No module named 'pandas')*